### PR TITLE
switching to GITHUB_OUTPUT env files

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -34,7 +34,7 @@ jobs:
           grep "new_version" .bumpversion.cfg
           x=$?
           echo $x
-          if [ $x -eq 0 ]; then echo "::set-output name=bump::present"; else echo "::set-output name=bump::missing"; fi
+          if [ $x -eq 0 ]; then echo "bump=present" >> $GITHUB_OUTPUT; else echo "bump=missing" >> $GITHUB_OUTPUT; fi
       - name: Print output
         run: |
           echo ${{ steps.check.outputs.bump }}


### PR DESCRIPTION
## What
Replacing set-output to the following:
```
- name: Set output
  run: echo "::set-output name={name}::{value}"
```
should be updated to write to the new GITHUB_STATE and GITHUB_OUTPUT environment files:
```
- name: Set output
  run: echo "{name}={value}" >> $GITHUB_OUTPUT
```

## Why
Blogpost for context: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Github are deprecating the use of printing "set-output" in steps for producing output from a step. This approach is being replaced with environment files.

A number of our Github actions make use of this mechanism and need to be adjusted by May 2023.

For guidance also see this tech pub article: https://www.notion.so/landtech/Cleaning-Windows-c35c76828a064b31818e125819dfd940

## Testing