### PR TITLE
[SC-24457] make 'Check Present' grep more strict to avoid conflicting with the other 'new_versions' in .bumpversion.cfg

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -31,7 +31,7 @@ jobs:
         id: check
         run: |
           set +e
-          grep "new_version" .bumpversion.cfg
+          grep "new_version[[:space:]]*=" .bumpversion.cfg
           x=$?
           echo $x
           if [ $x -eq 0 ]; then echo "bump=present" >> $GITHUB_OUTPUT; else echo "bump=missing" >> $GITHUB_OUTPUT; fi


### PR DESCRIPTION
## What
Currently, the [Check Present](https://github.com/landtechnologies/python-lib-workflows/blob/73d068785cd45d102794740835c06854db481da2/.github/workflows/bump_version.yml#L19) step does the following grep:
```bash
grep "new_version" .bumpversion.cfg
```

With the changes made at https://github.com/landtechnologies/template-python-library/pull/19 the grep will catch `new_version` `from replace = version="{new_version}"` when it's not supposed to.

This pr makes this grep a bit more strict by adding an '=' to the grep pattern. It should be enough to solve this issue.

**Important:** There's a small chance this can break things elsewhere. I didn't check that.

## Why
[Failed action](https://github.com/landtechnologies/data-lib-landtech-utils/actions/runs/3903536714/jobs/6668036353)