### PR TITLE
update ubuntu version for code artifact github workflow

### DIFF
--- a/.github/workflows/python_codeartifact_push.yml
+++ b/.github/workflows/python_codeartifact_push.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to CodeArtifact
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
## What
updated ubuntu version for `codeartifact_push` github workflow

## Why
ubuntu 18.04 is not supported by GitHub actions from april 2023

![image](https://user-images.githubusercontent.com/43442870/220352492-b81d9b85-a41a-400c-9070-f4ab1a8b3189.png)
